### PR TITLE
Bug#1: Null reference when trying to switch to a new scene.

### DIFF
--- a/SourceCode/addons/scene_manager/Scenes/SceneTransitionScreen.tscn
+++ b/SourceCode/addons/scene_manager/Scenes/SceneTransitionScreen.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=8 format=3 uid="uid://dxw2sqrjodv06"]
+[gd_scene load_steps=9 format=3 uid="uid://dxw2sqrjodv06"]
+
+[ext_resource type="Script" path="res://addons/scene_manager/Scripts/SceneTransitionScreen.gd" id="1_cr4vy"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_mpowv"]
 bg_color = Color(1, 1, 1, 1)
@@ -176,6 +178,7 @@ _data = {
 }
 
 [node name="SceneTransitionScreen" type="CanvasLayer"]
+script = ExtResource("1_cr4vy")
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 3
@@ -190,8 +193,8 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = 1152.0
-offset_bottom = 648.0
+offset_right = 2304.0
+offset_bottom = 1296.0
 grow_horizontal = 2
 grow_vertical = 2
 


### PR DESCRIPTION
Fixed a bug with the SceneTransitionScreen scene. Scene switching was throwing a null exception because the transition scene was not being loaded correctly. Hadd to attach the gd script to the scene.